### PR TITLE
feat: add compareptr linter

### DIFF
--- a/.github/workflows/go-linter-runner.yml
+++ b/.github/workflows/go-linter-runner.yml
@@ -23,9 +23,9 @@ jobs:
         with:
           action: run
           go_version: "1.24.0"
-          install_command: go install github.com/alingse/sundrylint/cmd/sundrylint@append-wrong
+          install_command: go install github.com/alingse/sundrylint/cmd/sundrylint@compare-ptr
           linter_command: sundrylint
-          includes: "[\"potential incorrect map append\"]"
+          includes: "[\"comparing pointers\"]"
           excludes: "[]"
           issue_id: 17
           repo_url: ${{ inputs.repo_url }}

--- a/.github/workflows/go-linter-runner.yml
+++ b/.github/workflows/go-linter-runner.yml
@@ -27,7 +27,7 @@ jobs:
           linter_command: sundrylint
           includes: "[\"comparing pointers\"]"
           excludes: "[]"
-          issue_id: 17
+          issue_id: 19
           repo_url: ${{ inputs.repo_url }}
           enable_testfile: false
         env:

--- a/compareptr.go
+++ b/compareptr.go
@@ -1,0 +1,36 @@
+package sundrylint
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+func LintComparePtr(pass *analysis.Pass, node *ast.BinaryExpr) (ds []analysis.Diagnostic) {
+	if node.Op != token.EQL && node.Op != token.NEQ {
+		return nil
+	}
+
+	xType := pass.TypesInfo.TypeOf(node.X)
+	yType := pass.TypesInfo.TypeOf(node.Y)
+
+	if isPointerType(xType) && isPointerType(yType) {
+		return []analysis.Diagnostic{
+			{
+				Pos:      node.Pos(),
+				End:      node.End(),
+				Category: LinterName,
+				Message:  SubLinterComparePtrMessage,
+			},
+		}
+	}
+
+	return nil
+}
+
+func isPointerType(t types.Type) bool {
+	_, ok := t.(*types.Pointer)
+	return ok
+}

--- a/compareptr.go
+++ b/compareptr.go
@@ -16,21 +16,154 @@ func LintComparePtr(pass *analysis.Pass, node *ast.BinaryExpr) (ds []analysis.Di
 	xType := pass.TypesInfo.TypeOf(node.X)
 	yType := pass.TypesInfo.TypeOf(node.Y)
 
-	if isPointerType(xType) && isPointerType(yType) {
-		return []analysis.Diagnostic{
-			{
-				Pos:      node.Pos(),
-				End:      node.End(),
-				Category: LinterName,
-				Message:  SubLinterComparePtrMessage,
-			},
-		}
+	if !isPointerType(xType) || !isPointerType(yType) {
+		return nil
 	}
 
-	return nil
+	// Check if both pointers point to basic numeric types
+	if !isBasicNumericPointerType(xType) || !isBasicNumericPointerType(yType) {
+		return nil
+	}
+
+	// Check if both operands are struct fields with getters
+	if !isStructFieldWithGetter(pass, node.X) || !isStructFieldWithGetter(pass, node.Y) {
+		return nil
+	}
+
+	return []analysis.Diagnostic{
+		{
+			Pos:      node.Pos(),
+			End:      node.End(),
+			Category: LinterName,
+			Message:  SubLinterComparePtrMessage,
+		},
+	}
 }
 
 func isPointerType(t types.Type) bool {
 	_, ok := t.(*types.Pointer)
 	return ok
+}
+
+func isBasicNumericPointerType(t types.Type) bool {
+	ptrType, ok := t.(*types.Pointer)
+	if !ok {
+		return false
+	}
+	return isBasicNumericType(ptrType.Elem())
+}
+
+func isBasicNumericType(t types.Type) bool {
+	basicType, ok := t.(*types.Basic)
+	if !ok {
+		return false
+	}
+	switch basicType.Kind() {
+	case types.Int, types.Int8, types.Int16, types.Int32, types.Int64,
+		types.Uint, types.Uint8, types.Uint16, types.Uint32, types.Uint64,
+		types.Float32, types.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func isStructFieldWithGetter(pass *analysis.Pass, expr ast.Expr) bool {
+	// Check if the expression is a selector expression (struct.field)
+	selExpr, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	// Get the type information for the selector
+	selObj := pass.TypesInfo.ObjectOf(selExpr.Sel)
+	if selObj == nil {
+		return false
+	}
+
+	// Check if it's a struct field
+	if _, ok := selObj.(*types.Var); !ok {
+		return false
+	}
+
+	// Get the struct type
+	structType := getStructType(pass, selExpr.X)
+	if structType == nil {
+		return false
+	}
+
+	// Check if the struct has a getter method for this field
+	fieldName := selObj.Name()
+	return hasGetterMethod(pass, selExpr.X, fieldName)
+}
+
+func getStructType(pass *analysis.Pass, expr ast.Expr) *types.Struct {
+	// Get the type of the expression
+	typ := pass.TypesInfo.TypeOf(expr)
+	if typ == nil {
+		return nil
+	}
+
+	// If it's a pointer, get the underlying type
+	if ptrType, ok := typ.(*types.Pointer); ok {
+		typ = ptrType.Elem()
+	}
+
+	// Check if it's a struct or named type
+	switch t := typ.(type) {
+	case *types.Struct:
+		return t
+	case *types.Named:
+		if structType, ok := t.Underlying().(*types.Struct); ok {
+			return structType
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func hasGetterMethod(pass *analysis.Pass, expr ast.Expr, fieldName string) bool {
+	// Construct the expected getter method name: Get + fieldName
+	getterName := "Get" + fieldName
+
+	// Get the type of the expression
+	typ := pass.TypesInfo.TypeOf(expr)
+	if typ == nil {
+		return false
+	}
+
+	// If it's a pointer, get the underlying type
+	if ptrType, ok := typ.(*types.Pointer); ok {
+		typ = ptrType.Elem()
+	}
+
+	// Check if it's a named type
+	namedType, ok := typ.(*types.Named)
+	if !ok {
+		return false
+	}
+
+	// Check methods directly on the named type
+	for i := 0; i < namedType.NumMethods(); i++ {
+		method := namedType.Method(i)
+		if method.Name() == getterName {
+			return isGetterMethodWithCorrectReturnType(method, "")
+		}
+	}
+
+	return false
+}
+
+func isGetterMethodWithCorrectReturnType(method *types.Func, fieldName string) bool {
+	sig := method.Type().(*types.Signature)
+
+	// Check if the method has no parameters and one return value
+	if sig.Params().Len() != 0 || sig.Results().Len() != 1 {
+		return false
+	}
+
+	// Check if the return type is a basic numeric type
+	returnType := sig.Results().At(0).Type()
+	return isBasicNumericType(returnType)
 }

--- a/linter.go
+++ b/linter.go
@@ -17,11 +17,13 @@ const (
 	SubLinterIteroverzero     = `iteroverzero`
 	SubLinterFuncresultunused = `funcresultunused`
 	SubLinterRangeappendall   = `rangeappendall`
+	SubLinterComparePtr       = `compareptr`
 
 	SubLinterRangeappendallMessage = `append all its data while range it`
 	SubLinterAppendNoAssignMessage = `call strconv.AppendX but not keep func result`
 	SubLinterMustCompileOutMessage = `call regexp.MustCompile with constant should be moved out of func`
 	SubLinterRepeatArgsMessage     = `call the func with repeat args from a sub-func`
+	SubLinterComparePtrMessage     = `comparing pointers with == or != can be error-prone`
 )
 
 type LinterSetting struct{}
@@ -67,6 +69,7 @@ func (a *analyzer) checkInspect(pass *analysis.Pass) (interface{}, error) {
 		(*ast.DeferStmt)(nil),
 		(*ast.KeyValueExpr)(nil),
 		(*ast.CompositeLit)(nil),
+		(*ast.BinaryExpr)(nil),
 	}
 	inspectorInfo.WithStack(checkNodes, func(n ast.Node, push bool, stack []ast.Node) (proceed bool) {
 		a.process(pass, n, push, stack)
@@ -91,6 +94,8 @@ func (a *analyzer) process(pass *analysis.Pass, n ast.Node, push bool, stack []a
 		a.report(pass, LintMapAppend(pass, node, stack))
 	case *ast.RangeStmt:
 		a.report(pass, LintIterOverZero(pass, node, stack))
+	case *ast.BinaryExpr:
+		a.report(pass, LintComparePtr(pass, node))
 	}
 }
 

--- a/linter_test.go
+++ b/linter_test.go
@@ -45,6 +45,10 @@ func TestAnalyzerSundryLint(t *testing.T) {
 			desc:     "mapappend",
 			settings: LinterSetting{},
 		},
+		{
+			desc:     "compareptr",
+			settings: LinterSetting{},
+		},
 	}
 
 	for _, test := range testCases {

--- a/testdata/src/compareptr/compareptr.go
+++ b/testdata/src/compareptr/compareptr.go
@@ -1,0 +1,13 @@
+package compareptr
+
+import "fmt"
+
+func Demo() {
+	var a int64 = 2
+	var b int64 = 1
+	var c = &a
+	var d = &b
+	if c == d { // want "comparing pointers with == or != can be error-prone"
+		fmt.Println("ok")
+	}
+}

--- a/testdata/src/compareptr/compareptr.go
+++ b/testdata/src/compareptr/compareptr.go
@@ -2,12 +2,74 @@ package compareptr
 
 import "fmt"
 
+type MyStruct struct {
+	Value *int64
+}
+
+func (m *MyStruct) GetValue() int64 {
+	return *m.Value
+}
+
+type OtherStruct struct {
+	Number *int32
+}
+
+func (o *OtherStruct) GetNumber() int32 {
+	return *o.Number
+}
+
 func Demo() {
+	val1 := int64(2)
+	val2 := int64(1)
+
+	s1 := &MyStruct{Value: &val1}
+	s2 := &MyStruct{Value: &val2}
+
+	// This should trigger the linter - comparing struct field pointers with getters
+	if s1.Value == s2.Value { // want "comparing pointers with == or != can be error-prone"
+		fmt.Println("ok")
+	}
+}
+
+func DemoNoTrigger() {
+	// Simple pointer comparison - should NOT trigger (not struct fields)
 	var a int64 = 2
 	var b int64 = 1
 	var c = &a
 	var d = &b
-	if c == d { // want "comparing pointers with == or != can be error-prone"
-		fmt.Println("ok")
+	if c == d {
+		fmt.Println("simple pointer comparison")
+	}
+
+	// Struct field without getter - should NOT trigger
+	type NoGetterStruct struct {
+		Field *int64
+	}
+	ng1 := &NoGetterStruct{Field: &a}
+	ng2 := &NoGetterStruct{Field: &b}
+	if ng1.Field == ng2.Field {
+		fmt.Println("struct field without getter")
+	}
+
+	// Non-numeric pointer comparison - should NOT trigger
+	type StringStruct struct {
+		Text *string
+	}
+	str1 := "hello"
+	str2 := "world"
+	ss1 := &StringStruct{Text: &str1}
+	ss2 := &StringStruct{Text: &str2}
+	if ss1.Text == ss2.Text {
+		fmt.Println("string pointer comparison")
+	}
+
+	// Getter with wrong return type - should NOT trigger
+	type WrongReturnStruct struct {
+		Value *int64
+	}
+	wr1 := &WrongReturnStruct{Value: &a}
+	wr2 := &WrongReturnStruct{Value: &b}
+	if wr1.Value == wr2.Value {
+		fmt.Println("wrong return type")
 	}
 }


### PR DESCRIPTION
- Add new linter to detect comparisons between pointers
- Implement LintComparePtr function in compareptr.go
- Integrate linter into main processing logic in linter.go
- Add test case for compareptr in linter_test.go
- Include test data in testdata/src/compareptr/